### PR TITLE
Update jrpc2 to v0.30.0.

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -4,6 +4,6 @@ go 1.16
 
 require (
 	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210521184019-c5ad59b459ec
-	github.com/creachadair/jrpc2 v0.18.0
-	github.com/google/go-cmp v0.5.1
+	github.com/creachadair/jrpc2 v0.30.0
+	github.com/google/go-cmp v0.5.6
 )

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,9 +1,9 @@
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210521184019-c5ad59b459ec h1:EEyRvzmpEUZ+I8WmD5cw/vY8EqhambkOqy5iFr0908A=
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210521184019-c5ad59b459ec/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
-github.com/creachadair/jrpc2 v0.18.0 h1:eri9qZeiVwPSVTLqUk0MYixlzdBMdaEBi9AgrihuGIA=
-github.com/creachadair/jrpc2 v0.18.0/go.mod h1:gaeysmTjY/kHSaCEjxF1pHXl8bc0X5otQPnQiA6r9Xk=
-github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
-github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/creachadair/jrpc2 v0.30.0 h1:WYC+oqMxj3XEnaYg1l2gurtiawcRP7g8BLC0p8rpZkc=
+github.com/creachadair/jrpc2 v0.30.0/go.mod h1:w+GXZGc+NwsH0xsUOgeLBIIRM0jBOSTXhv28KaWGRZU=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/server/internal/server/server.go
+++ b/server/internal/server/server.go
@@ -29,7 +29,7 @@ func NewServer(srvCtx context.Context) *server {
 }
 
 func (srv *server) SetLogger(logger *log.Logger) {
-	srv.jrpcOptions.Logger = logger
+	srv.jrpcOptions.Logger = jrpc2.StdLogger(logger)
 	srv.logger = logger
 }
 

--- a/server/internal/server/server_test.go
+++ b/server/internal/server/server_test.go
@@ -32,7 +32,7 @@ func Test_server_initialize(t *testing.T) {
 	clientCh := channel.LSP(clientStdin, clientStdout)
 	opts := &jrpc2.ClientOptions{}
 	if testing.Verbose() {
-		opts.Logger = testLogger(os.Stdout, "[CLIENT] ")
+		opts.Logger = jrpc2.StdLogger(testLogger(os.Stdout, "[CLIENT] "))
 	}
 	client := jrpc2.NewClient(clientCh, opts)
 


### PR DESCRIPTION
In preparation for committing to a stable v1 release for jrpc2 package, I have
made a number of updates to the library to simplify the API a bit. These
changes are discussed in creachadair/jrpc2#46 if you would like to offer input.

This commit updates the package version used here to the latest tag,
and updates usage as required in this package.